### PR TITLE
Update g910-gkeys.service

### DIFF
--- a/g910-gkeys.service
+++ b/g910-gkeys.service
@@ -3,7 +3,7 @@ Description=Support for Logitech g910 keyboard gkeys
 Documentation=https://github.com/JSubelj/g910-gkey-macro-support/wiki
 
 [Service]
-ExecStart=/usr/bin/g910-gkeys
+ExecStart=/usr/local/bin/g910-gkeys
 TimeoutStopSec=3
 
 


### PR DESCRIPTION
Installation script copies main script to `/usr/local/bin/g910-gkeys`, not `/usr/bin/g910-gkeys`, so the systemd service fails.