### PR TITLE
Explicitly catch the keyerror instead of swallowing all errors

### DIFF
--- a/lib/functionalities/gkey_functionality.py
+++ b/lib/functionalities/gkey_functionality.py
@@ -32,7 +32,7 @@ def resolve_config(key):
     command = key_config.get("hotkey_type","nothing")
     try:
         command = hotkey_type.type[command]
-    except:
+    except KeyError:
         raise Exception("hotkey_type: \""+command+"\" for key "+key+" not known! hotkey_types can only be: nothing, typeout, shortcut and run!")
     if command == 0:
 


### PR DESCRIPTION
I was reading through the code and saw this.  Blanket Exception swallowing has caught me a few times, so I thought I would save you the trouble.

Thank you by the way for this library made it super easy to add some hotkeys.