### PR TITLE
Bugfix lost shifts

### DIFF
--- a/lib/data_mappers/char_uinput_mapper.py
+++ b/lib/data_mappers/char_uinput_mapper.py
@@ -34,14 +34,9 @@ keys = {
         'esc': click(uinput.KEY_ESC),
         "enter": click(uinput.KEY_ENTER),
         "capslock": click(uinput.KEY_CAPSLOCK),
-        #unfortunately these aren't already supported by uinput
         'end':click(uinput.KEY_END),
         'insert':click(uinput.KEY_INSERT),
-        #but on my machine we can simulate them with: How universal is this?
-        #"insert": wrap_shift(click(uinput.KEY_KP0)),
-        #"end": wrap_shift(click(uinput.KEY_KP1)),
-
-
+        
         # keypad
         "NUM0": click(uinput.KEY_KP0),
         "NUM1": click(uinput.KEY_KP1),

--- a/lib/data_mappers/char_uinput_mapper.py
+++ b/lib/data_mappers/char_uinput_mapper.py
@@ -34,6 +34,13 @@ keys = {
         'esc': click(uinput.KEY_ESC),
         "enter": click(uinput.KEY_ENTER),
         "capslock": click(uinput.KEY_CAPSLOCK),
+        #unfortunately these aren't already supported by uinput
+        #'end':click(uinput.KEY_END)        
+        #'insert':click(uinput.KEY_INSERT)
+        #but on my machine we can simulate them with: How universal is this?
+        "insert": wrap_shift(click(uinput.KEY_KP0)),
+        "end": wrap_shift(click(uinput.KEY_KP1)),
+        
 
         # keypad
         "NUM0": click(uinput.KEY_KP0),

--- a/lib/data_mappers/char_uinput_mapper.py
+++ b/lib/data_mappers/char_uinput_mapper.py
@@ -35,11 +35,11 @@ keys = {
         "enter": click(uinput.KEY_ENTER),
         "capslock": click(uinput.KEY_CAPSLOCK),
         #unfortunately these aren't already supported by uinput
-        #'end':click(uinput.KEY_END)
-        #'insert':click(uinput.KEY_INSERT)
+        'end':click(uinput.KEY_END),
+        'insert':click(uinput.KEY_INSERT),
         #but on my machine we can simulate them with: How universal is this?
-        "insert": wrap_shift(click(uinput.KEY_KP0)),
-        "end": wrap_shift(click(uinput.KEY_KP1)),
+        #"insert": wrap_shift(click(uinput.KEY_KP0)),
+        #"end": wrap_shift(click(uinput.KEY_KP1)),
 
 
         # keypad

--- a/lib/data_mappers/char_uinput_mapper.py
+++ b/lib/data_mappers/char_uinput_mapper.py
@@ -36,7 +36,7 @@ keys = {
         "capslock": click(uinput.KEY_CAPSLOCK),
         'end':click(uinput.KEY_END),
         'insert':click(uinput.KEY_INSERT),
-        
+
         # keypad
         "NUM0": click(uinput.KEY_KP0),
         "NUM1": click(uinput.KEY_KP1),

--- a/lib/data_mappers/char_uinput_mapper.py
+++ b/lib/data_mappers/char_uinput_mapper.py
@@ -35,12 +35,12 @@ keys = {
         "enter": click(uinput.KEY_ENTER),
         "capslock": click(uinput.KEY_CAPSLOCK),
         #unfortunately these aren't already supported by uinput
-        #'end':click(uinput.KEY_END)        
+        #'end':click(uinput.KEY_END)
         #'insert':click(uinput.KEY_INSERT)
         #but on my machine we can simulate them with: How universal is this?
         "insert": wrap_shift(click(uinput.KEY_KP0)),
         "end": wrap_shift(click(uinput.KEY_KP1)),
-        
+
 
         # keypad
         "NUM0": click(uinput.KEY_KP0),

--- a/lib/uinput_keyboard/keyboard.py
+++ b/lib/uinput_keyboard/keyboard.py
@@ -50,9 +50,17 @@ def shortcut(value, keymap, device):
         uinput_combo = []
         for key_string in combo:
             if len(key_string) == 1:
-                uinput_combo.append(keys[keymap][key_string][0][0])
+                key_def = keys[keymap][key_string]
+                for press,state in key_def:
+                    uinput_combo.append(press)
+                    if state == 3:
+                        break
             else:
-                uinput_combo.append(keys["control"][key_string][0][0])
+                key_def = keys["control"][key_string]
+                for press,state in key_def:
+                    uinput_combo.append(press)
+                    if state == 3:
+                        break
 
         uinput_groups.append(uinput_combo)
 

--- a/lib/uinput_keyboard/keyboard.py
+++ b/lib/uinput_keyboard/keyboard.py
@@ -51,16 +51,13 @@ def shortcut(value, keymap, device):
         for key_string in combo:
             if len(key_string) == 1:
                 key_def = keys[keymap][key_string]
-                for press,state in key_def:
-                    uinput_combo.append(press)
-                    if state == 3:
-                        break
             else:
                 key_def = keys["control"][key_string]
-                for press,state in key_def:
-                    uinput_combo.append(press)
-                    if state == 3:
-                        break
+                
+            for press,state in key_def:
+                uinput_combo.append(press)
+                if state == 3:
+                    break
 
         uinput_groups.append(uinput_combo)
 

--- a/lib/uinput_keyboard/keyboard.py
+++ b/lib/uinput_keyboard/keyboard.py
@@ -53,7 +53,7 @@ def shortcut(value, keymap, device):
                 key_def = keys[keymap][key_string]
             else:
                 key_def = keys["control"][key_string]
-                
+
             for press,state in key_def:
                 uinput_combo.append(press)
                 if state == 3:


### PR DESCRIPTION
Feature: adds 'end' and 'insert' by wrapping 'NUM0' and 'NUM1' respectively with shift

Fixes bug where keys defined by a wrapping a key with a alt/shift/ctrl loses all content except the outermost shift.