### PR TITLE
turn on shell flag to allow 'run' macros to be more than one word long

### DIFF
--- a/lib/functionalities/gkey_functionality.py
+++ b/lib/functionalities/gkey_functionality.py
@@ -17,7 +17,8 @@ def execute_release(device):
     keyboard.release(device)
 
 def execute_command(command):
-    subprocess.Popen(command, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, shell=True)
+    #subprocess.Popen(command, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, shell=True)
+    subprocess.Popen(['bash', '-c', command], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
 
 def resolve_config(key):
 

--- a/lib/functionalities/gkey_functionality.py
+++ b/lib/functionalities/gkey_functionality.py
@@ -17,7 +17,7 @@ def execute_release(device):
     keyboard.release(device)
 
 def execute_command(command):
-    subprocess.Popen(command, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    subprocess.Popen(command, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, shell=True)
 
 def resolve_config(key):
 

--- a/lib/functionalities/gkey_functionality.py
+++ b/lib/functionalities/gkey_functionality.py
@@ -18,7 +18,7 @@ def execute_release(device):
 
 def execute_command(command):
     #subprocess.Popen(command, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, shell=True)
-    subprocess.Popen(['bash', '-c', command], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    subprocess.Popen(['/bin/bash', '-c', command], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
 
 def resolve_config(key):
 


### PR DESCRIPTION
This is probably what you meant to do. Writing long command lines as arrays of strings in json files is really annoying.