### PR TITLE
suppress 'no match' warnings on known LED return values

### DIFF
--- a/lib/g910_gkey_mapper.py
+++ b/lib/g910_gkey_mapper.py
@@ -103,6 +103,9 @@ def main():
                         list(command_bytearray.commands.values()).index(b)]
                     log.debug(f"Pressed {key}, bytecode: {b}")
                     emitKeys(device, key)
+                elif b[:3] in (bytearray(b'\x11\xff\x0f'), bytearray(b'\x11\xff\x10'), bytearray(b'\x11\xff\xff')):
+                    #Suppress warnings on these values, these are return values from LEDs being set.
+                    pass
                 else:
                     log.warning(str(b) + ' no match')
         except SystemExit:


### PR DESCRIPTION
I know we're not interfacing with g810-LED from here, but when g810-LED being used, the keyboard does generate a lot of noise, and we don't need to log it all, since it's easy to identify those return codes.

Just an aesthetic issue really with the log file filling up when the keyboard LEDs are being set g810-LED.