### PR TITLE
strengthens systemd copy : Create destination directory first.

### DIFF
--- a/installer.sh
+++ b/installer.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
+DEST=/usr/lib/systemd/system
 
 python3 setup.py install --record files.txt
-cp g910-gkeys.service /usr/lib/systemd/system/g910-gkeys.service
+mkdir -p "$DEST" && cp g910-gkeys.service "$DEST"
 systemctl daemon-reload


### PR DESCRIPTION
related to [#33](https://github.com/JSubelj/g910-gkey-macro-support/issues/33). 
https://stackoverflow.com/questions/1529946/linux-copy-and-create-destination-dir-if-it-does-not-exist