### PR TITLE
Use system-dependant "systemd system unit" directory instead of /usr/…

### DIFF
--- a/installer.sh
+++ b/installer.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 
+# get system unit directory
+DEST=$(pkg-config systemd --variable=systemdsystemunitdir)
 
 python3 setup.py install --record files.txt
-cp g910-gkeys.service /usr/lib/systemd/system/g910-gkeys.service
+cp g910-gkeys.service "$DEST"/g910-gkeys.service
 systemctl daemon-reload


### PR DESCRIPTION
Linked to [#33](https://github.com/JSubelj/g910-gkey-macro-support/issues/33), as /usr/lib/systemd/system is not part of systemd on Debian based systems (shown by dpkg-query -L systemd).

The systemd "system unit" directory is system dependant. Use the correct one instead of hardcoded path.

Examples:
- On Fedora based systems (CentOS, etc...), it will be /usr/lib/systemd/system
- On Debian based systems (Ubuntu, etc...), it will be /lib/systemd/system

Not using systemd-dependant directory could lead to missing directory, as explained in :
[distro systemd dirs](https://unix.stackexchange.com/questions/206315/whats-the-difference-between-usr-lib-systemd-system-and-etc-systemd-system)