### PR TITLE
uninstall script, improve install script, upd README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Because I didn't find any GKey support for Logitech G910 keyboard I decided to create this GKey mapper.
 Code is based on an [issue](https://github.com/CReimer/g910-gkey-uinput/issues/3)
-in [g910-gkey-uinput](https://github.com/CReimer/g910-gkey-uinput) project. I expanded the code, so that it is more 
+in [g910-gkey-uinput](https://github.com/CReimer/g910-gkey-uinput) project. I expanded the code, so that it is more
 user friendly to add functionality to GKeys.
 
 The code is tested on Logitech G910 keyboard, OS: Manjaro, 4.19.1 Linux kernel, DE: kde plasma 5.14.3.
@@ -19,29 +19,28 @@ To use this project you need:
  - ~~[g810-led controller](https://github.com/MatMoul/g810-led)~~
  - uinput kernel module (more on this [here](http://tjjr.fi/sw/python-uinput/#Usage))
  - pip requirements are stored in requirements.txt
- 
+
 ## Installation \[[AUR](https://aur.archlinux.org/packages/g910-gkeys-git/)\]
  - ~~install [g810-led-git](https://github.com/MatMoul/g810-led) for your distro (for Arch based distros: [aur](https://aur.archlinux.org/packages/g810-led-git/))~~
  - ~~disable Gkeys to Fkeys mapping: `g910-led -gkm 1` (probably will include that on program start)~~
- - load uinput kernel module: `modprobe uinput` (on Manjaro is loaded by default afaik) 
+ - load uinput kernel module: `modprobe uinput` (on Manjaro is loaded by default afaik)
  - clone repo: `git clone https://github.com/JSubelj/g910-gkey-macro-support.git`
  - move to cloned repo: `cd g910-gkey-macro-support`
  - run the installer shell: `chmod +x installer.sh; sudo ./installer.sh`
- - This will install the module and set a command `g910-gkeys`, add a service file to `/usr/lib/systemd/system/g910-gkeys.service` and reload systemd daemon
- - start the daemon: `systemctl start g910-gkeys`
- - you can also add it to start on startup: `systemctl enable g910-gkeys`
- 
+ - This will install the module, set a command `g910-gkeys`, add a service file to `/usr/lib/systemd/system/g910-gkeys.service` or `/lib/systemd/system/g910-gkeys.service`, install a default configuration file in `/etc/g910-gkeys/config.json` if none exists, end finally enable and start this service.
+
 ## Uninstalling
- - Uninstalling can be done with files.txt that was created on install (if you deleted it you can always run the installer again to create it)
- - run command: `cat files.txt | sudo xargs rm -rf`
- - list pip packages that include g910: `pip list | grep g910`
- - remove the ones that concern this driver: `pip uninstall ${pkgs to uninstall}`
- - it is also recommended to disable the service: `systemctl disable g910-gkeys`
- - and remove it from system folder: `rm /usr/lib/systemd/system/g910-gkeys.service`
- - you can also delete the configuration: `rm /etc/g910-gkeys -rf`
- 
+ - run the uninstall script: `chmod +x uninstall.sh; sudo ./uninstall.sh`. This will do the following, that you can do manually instead:
+ - Disable and stop the service: `sudo systemctl disable --now g910-gkeys`
+ - Remove installed files (list is in files.txt): `sudo xargs --arg-file=files.txt rm -rf`
+  Note: if you deletedfiles.txt you can always run the installer again to create it.
+ - list pip packages that include g910-gkeys: `pip (or pip3) list | grep g910-gkeys`
+ - remove the ones that concern this driver: `pip (or pip3) uninstall ${pkgs to uninstall}`
+ - remove configuration directory if `-a` option was provided: `rm -rf /etc/g910-gkeys`
+ - You may use the "-d" switch to have uninstall.sh to perform a dry-run (no action will be done, only displayed).
+
 ## Configuration
-Configuration should be located in `/etc/g910-gkeys/config.json` and should be syntactically correct. Example 
+Configuration should be located in `/etc/g910-gkeys/config.json` and should be syntactically correct. Example
 configuration can be found in docs folder: [ex_config](docs/ex_config/ex_config.json).
 Currently the mapper supports three types of hotkeys (also described in [hotkey_types.txt](docs/hotkey_types.txt)):
  * `"typeout"` - Type out (ex. clicking on GKey types out a string)
@@ -57,7 +56,7 @@ To add a hotkey add to `config.json` the following code:
   }
 ```
 
-Depending on the hotkey command, the syntax for "do" is different (supported characters for typeout and 
+Depending on the hotkey command, the syntax for "do" is different (supported characters for typeout and
 hotkeys are listed in [supported_keys.txt](docs/supported_keys.txt)):
  * `"typeout"` - Typeout syntax is same as you would type text out (ex. "tyPe Me Out!")
  * `"shortcut"` - Shortcuts are separated by a plus sign and a comma (ex. "ctrl+c,ctrl+v")
@@ -66,10 +65,10 @@ hotkeys are listed in [supported_keys.txt](docs/supported_keys.txt)):
 
 
 ### Disclaimer
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, 
-INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. 
-IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE 
-BE LIABLE FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, 
-ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS 
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT.
+IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE
+BE LIABLE FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 IN THE SOFTWARE.

--- a/installer.sh
+++ b/installer.sh
@@ -1,8 +1,23 @@
 #!/usr/bin/env bash
 
+# check if we are 'root' user.
+(( $EUID != 0 )) && echo Must be root to run this script. Exiting. &&
+    exit 1
+
 # get system unit directory
 DEST=$(pkg-config systemd --variable=systemdsystemunitdir)
+CONFDIR=/etc/g910-gkeys
+FILES=files.txt
 
-python3 setup.py install --record files.txt
+python3 setup.py install --record "$FILES"
+
+# systemd service file
+echo "$DEST"/g910-gkeys.service >> "$FILES"
 cp g910-gkeys.service "$DEST"/g910-gkeys.service
-systemctl daemon-reload
+
+# configuration file - will not overwrite existing files.
+[[ -d "$CONFDIR" ]] ||  mkdir "$CONFDIR"
+rsync -a -v --ignore-existing config/* "$CONFDIR"
+
+# enable and start service
+systemctl enable --now g910-gkeys.service

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+#
+# uninstall/removes g910-gkeys.
+#
+# options:
+#  -a: will also remove /etc/g910-gkeys/ configuration directory.
+#  -d: dry-run: will display actions without doing anything
+#
+# TODO: remove possible faulty previous versions files (in /etc/systemd/system
+#       and /usr/lib/systemd/system)
+#
+# BUGS: files.txt is not correct:
+#     - it does not contain directories.
+#     - files added later (_pycache__) are not removed
+#   I would suggest to use egg directory, instead of a list of files.
+#
+
+FILESLST=files.txt
+PIPCMD=""
+REMOVECONF=n
+DRYRUN=""
+CONFDIR=/etc/g910-gkeys
+
+# check if we are 'root' user.
+(( $EUID != 0 )) && echo Must be root to run this script. Exiting. &&
+    exit 1
+
+usage() {
+    echo "usage: ${0##*/}" [-a][-d]
+    echo Exiting.
+}
+
+# in case we need more options, better to use getopts.
+while getopts ad opt; do
+    case "$opt" in
+        a) REMOVECONF=y
+           ;;
+        d) DRYRUN="echo"
+           ;;
+        *) usage
+           exit 1
+           ;;
+    esac
+done
+
+# determine if we should use pip or pip3, pip3 being preferred
+for p in pip pip3; do
+    type "$p" &>/dev/null && PIPCMD="$p"
+done
+
+# stops and disable service
+systemctl disable --now g910-gkeys
+
+# remove all installed files (not configuration files, in /etc/g910-gkeys)
+[[ -f "$FILESLST" ]] && ${DRYRUN} xargs --arg-file="$FILESLST" rm -rf
+
+# remove configuration file[s] if requested
+[[ "$REMOVECONF" = y ]] && ${DRYRUN} rm -rf "$CONFDIR"
+
+if [[ -n "$PIPCMD" ]]; then
+    PIPLST=$($PIPCMD list | grep 'g910-gkeys' | cut -d " " -f 1)
+    [[ -n "$PIPLST" ]] && ${DRYRUN} ${PIPCMD} uninstall "$PIPLST"
+fi
+
+echo
+echo ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+echo + Please remove "g910-gkeys.service" in "/usr/lib/systemd/system"
+echo + and "/etc/systemd/system.conf", if they exist.
+echo ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++


### PR DESCRIPTION
- added uninstall script (globally following instructions present in README.md)
    + options: -a (will remove config files), -d (dry-run)
- updated install/uninstall scripts to check if run as root
- installer.sh:
    + Install default config.json if not present.
    + added systemd file in files.txt
    + replaced systemctl 'daemon-reload' with specific enable/start for g910-gkeys.

Bugs: files.txt (as explained in #37) is incomplete (dirs are not removed).
 
