### PR TITLE
Fix example config, which did not work since F-keys must be uppercase

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -7,7 +7,7 @@
   },
   "g2": {
     "hotkey_type": "shortcut",
-    "do": "alt+f4"
+    "do": "alt+F4"
   },
   "g5": {
     "hotkey_type": "nothing"

--- a/docs/ex_config/ex_config.json
+++ b/docs/ex_config/ex_config.json
@@ -7,7 +7,7 @@
   },
   "g2": {
     "hotkey_type": "shortcut",
-    "do": "alt+f4"
+    "do": "alt+F4"
   },
   "g5": {
     "hotkey_type": "nothing"


### PR DESCRIPTION
Minor bug: example config for g2 does not work, since 'F-keys' only work in shortcuts when uppercase.

Bug could also be fixed adding lowercase bindings for f-keys.